### PR TITLE
fix a build error about compile 'com.crystal:crystalrangeseekbar:1.1.1'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,11 @@ buildscript {
     }
 }
 
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
修复因 com.crystal:crystalrangeseekbar:1.1.1 缺失而导致的无法编译的问题。

详情：

https://github.com/veryyoung/WechatLuckyMoney/issues/60
https://github.com/veryyoung/WechatLuckyMoney/pull/81